### PR TITLE
Move imports onto separate lines

### DIFF
--- a/sha2/sha256.py
+++ b/sha2/sha256.py
@@ -2,7 +2,10 @@
 __author__ = 'Thomas Dixon'
 __license__ = 'MIT'
 
-import copy, struct, sys
+import copy
+import struct
+import sys
+
 
 def new(m=None):
     return sha256(m)


### PR DESCRIPTION
https://www.python.org/dev/peps/pep-0008/#imports

> Imports should usually be on separate lines:

```
Yes: import os
     import sys

No:  import sys, os
```

Small little edit :) No biggie if you disagree, I just think it looks nicer