### PR TITLE
Converted to python3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: python
 python:
-    - "2.7"
+    - "3.12"
 script: nosetests

--- a/sha2/sha224.py
+++ b/sha2/sha224.py
@@ -4,11 +4,15 @@ __license__ = 'MIT'
 
 from sha2.sha256 import sha256
 
-def new(m=None):
+
+def new(m: bytes | None = None) -> 'sha224':
     return sha224(m)
 
+
 class sha224(sha256):
-    _h = (0xc1059ed8L, 0x367cd507L, 0x3070dd17L, 0xf70e5939L,
-          0xffc00b31L, 0x68581511L, 0x64f98fa7L, 0xbefa4fa4L)
+    # fmt: off
+    _h = (0xc1059ed8, 0x367cd507, 0x3070dd17, 0xf70e5939,
+          0xffc00b31, 0x68581511, 0x64f98fa7, 0xbefa4fa4)
+    # fmt: on
     _output_size = 7
     digest_size = 28

--- a/sha2/sha256.py
+++ b/sha2/sha256.py
@@ -7,57 +7,58 @@ import struct
 import sys
 
 
-def new(m=None):
+def new(m: bytes | None = None):
     return sha256(m)
 
-class sha256(object):
-    _k = (0x428a2f98L, 0x71374491L, 0xb5c0fbcfL, 0xe9b5dba5L,
-          0x3956c25bL, 0x59f111f1L, 0x923f82a4L, 0xab1c5ed5L,
-          0xd807aa98L, 0x12835b01L, 0x243185beL, 0x550c7dc3L,
-          0x72be5d74L, 0x80deb1feL, 0x9bdc06a7L, 0xc19bf174L,
-          0xe49b69c1L, 0xefbe4786L, 0x0fc19dc6L, 0x240ca1ccL,
-          0x2de92c6fL, 0x4a7484aaL, 0x5cb0a9dcL, 0x76f988daL,
-          0x983e5152L, 0xa831c66dL, 0xb00327c8L, 0xbf597fc7L,
-          0xc6e00bf3L, 0xd5a79147L, 0x06ca6351L, 0x14292967L,
-          0x27b70a85L, 0x2e1b2138L, 0x4d2c6dfcL, 0x53380d13L,
-          0x650a7354L, 0x766a0abbL, 0x81c2c92eL, 0x92722c85L,
-          0xa2bfe8a1L, 0xa81a664bL, 0xc24b8b70L, 0xc76c51a3L,
-          0xd192e819L, 0xd6990624L, 0xf40e3585L, 0x106aa070L,
-          0x19a4c116L, 0x1e376c08L, 0x2748774cL, 0x34b0bcb5L,
-          0x391c0cb3L, 0x4ed8aa4aL, 0x5b9cca4fL, 0x682e6ff3L,
-          0x748f82eeL, 0x78a5636fL, 0x84c87814L, 0x8cc70208L,
-          0x90befffaL, 0xa4506cebL, 0xbef9a3f7L, 0xc67178f2L)
-    _h = (0x6a09e667L, 0xbb67ae85L, 0x3c6ef372L, 0xa54ff53aL,
-          0x510e527fL, 0x9b05688cL, 0x1f83d9abL, 0x5be0cd19L)
+
+class sha256:
+    # fmt: off
+    _k = (0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5,
+          0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+          0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
+          0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+          0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc,
+          0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+          0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7,
+          0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+          0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
+          0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+          0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3,
+          0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+          0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5,
+          0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+          0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+          0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2)
+    _h = (0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a,
+          0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19)
+    # fmt: on
     _output_size = 8
-    
+
     blocksize = 1
     block_size = 64
     digest_size = 32
-    
-    def __init__(self, m=None):        
-        self._buffer = ''
+
+    def __init__(self, m: bytes | None = None):
+        self._buffer = b''
         self._counter = 0
-        
+
         if m is not None:
-            if type(m) is not str:
-                raise TypeError, '%s() argument 1 must be string, not %s' % (self.__class__.__name__, type(m).__name__)
             self.update(m)
-        
-    def _rotr(self, x, y):
-        return ((x >> y) | (x << (32-y))) & 0xFFFFFFFFL
-                    
-    def _sha256_process(self, c):
-        w = [0]*64
-        w[0:16] = struct.unpack('!16L', c)
-        
+
+    def _rotr(self, x: int, y: int) -> int:
+        return ((x >> y) | (x << (32 - y))) & 0xFFFFFFFF
+
+    def _sha256_process(self, c_in: bytes) -> None:
+        w = [0] * 64
+        w[0:16] = struct.unpack('!16L', c_in)
+
         for i in range(16, 64):
-            s0 = self._rotr(w[i-15], 7) ^ self._rotr(w[i-15], 18) ^ (w[i-15] >> 3)
-            s1 = self._rotr(w[i-2], 17) ^ self._rotr(w[i-2], 19) ^ (w[i-2] >> 10)
-            w[i] = (w[i-16] + s0 + w[i-7] + s1) & 0xFFFFFFFFL
-        
-        a,b,c,d,e,f,g,h = self._h
-        
+            s0 = self._rotr(w[i - 15], 7) ^ self._rotr(w[i - 15], 18) ^ (w[i - 15] >> 3)
+            s1 = self._rotr(w[i - 2], 17) ^ self._rotr(w[i - 2], 19) ^ (w[i - 2] >> 10)
+            w[i] = (w[i - 16] + s0 + w[i - 7] + s1) & 0xFFFFFFFF
+
+        a, b, c, d, e, f, g, h = self._h
+
         for i in range(64):
             s0 = self._rotr(a, 2) ^ self._rotr(a, 13) ^ self._rotr(a, 22)
             maj = (a & b) ^ (a & c) ^ (b & c)
@@ -65,46 +66,46 @@ class sha256(object):
             s1 = self._rotr(e, 6) ^ self._rotr(e, 11) ^ self._rotr(e, 25)
             ch = (e & f) ^ ((~e) & g)
             t1 = h + s1 + ch + self._k[i] + w[i]
-            
+
             h = g
             g = f
             f = e
-            e = (d + t1) & 0xFFFFFFFFL
+            e = (d + t1) & 0xFFFFFFFF
             d = c
             c = b
             b = a
-            a = (t1 + t2) & 0xFFFFFFFFL
-            
-        self._h = [(x+y) & 0xFFFFFFFFL for x,y in zip(self._h, [a,b,c,d,e,f,g,h])]
-        
-    def update(self, m):
+            a = (t1 + t2) & 0xFFFFFFFF
+
+        self._h = [(x + y) & 0xFFFFFFFF for x, y in zip(self._h, [a, b, c, d, e, f, g, h])]
+
+    def update(self, m: bytes) -> None:
         if not m:
             return
-        if type(m) is not str:
-            raise TypeError, '%s() argument 1 must be string, not %s' % (sys._getframe().f_code.co_name, type(m).__name__)
-        
+        if not isinstance(m, bytes):
+            raise TypeError('%s() argument 1 must be bytes, not %s' % (sys._getframe().f_code.co_name, type(m).__name__))
+
         self._buffer += m
         self._counter += len(m)
-        
+
         while len(self._buffer) >= 64:
             self._sha256_process(self._buffer[:64])
             self._buffer = self._buffer[64:]
-            
-    def digest(self):
+
+    def digest(self) -> bytes:
         mdi = self._counter & 0x3F
-        length = struct.pack('!Q', self._counter<<3)
-        
+        length = struct.pack('!Q', self._counter << 3)
+
         if mdi < 56:
-            padlen = 55-mdi
+            padlen = 55 - mdi
         else:
-            padlen = 119-mdi
-        
+            padlen = 119 - mdi
+
         r = self.copy()
-        r.update('\x80'+('\x00'*padlen)+length)
-        return ''.join([struct.pack('!L', i) for i in r._h[:self._output_size]])
-        
-    def hexdigest(self):
-        return self.digest().encode('hex')
-        
-    def copy(self):
+        r.update(b'\x80' + (b'\x00' * padlen) + length)
+        return b''.join([struct.pack('!L', i) for i in r._h[: self._output_size]])
+
+    def hexdigest(self) -> str:
+        return self.digest().hex()
+
+    def copy(self) -> 'sha256':
         return copy.deepcopy(self)

--- a/sha2/sha384.py
+++ b/sha2/sha384.py
@@ -4,11 +4,15 @@ __license__ = 'MIT'
 
 from sha2.sha512 import sha512
 
-def new(m=None):
+
+def new(m: bytes | None = None) -> 'sha384':
     return sha384(m)
 
+
 class sha384(sha512):
-    _h = (0xcbbb9d5dc1059ed8L, 0x629a292a367cd507L, 0x9159015a3070dd17L, 0x152fecd8f70e5939L,
-          0x67332667ffc00b31L, 0x8eb44a8768581511L, 0xdb0c2e0d64f98fa7L, 0x47b5481dbefa4fa4L)
+    # fmt: off
+    _h = (0xcbbb9d5dc1059ed8, 0x629a292a367cd507, 0x9159015a3070dd17, 0x152fecd8f70e5939,
+          0x67332667ffc00b31, 0x8eb44a8768581511, 0xdb0c2e0d64f98fa7, 0x47b5481dbefa4fa4)
+    # fmt: on
     _output_size = 6
     digest_size = 48

--- a/sha2/sha512.py
+++ b/sha2/sha512.py
@@ -2,62 +2,66 @@
 __author__ = 'Thomas Dixon'
 __license__ = 'MIT'
 
-import copy, struct, sys
+import copy
+import struct
+import sys
 
-def new(m=None):
+
+def new(m: bytes | None = None) -> 'sha512':
     return sha512(m)
 
-class sha512(object):
-    _k = (0x428a2f98d728ae22L, 0x7137449123ef65cdL, 0xb5c0fbcfec4d3b2fL, 0xe9b5dba58189dbbcL,
-          0x3956c25bf348b538L, 0x59f111f1b605d019L, 0x923f82a4af194f9bL, 0xab1c5ed5da6d8118L,
-          0xd807aa98a3030242L, 0x12835b0145706fbeL, 0x243185be4ee4b28cL, 0x550c7dc3d5ffb4e2L,
-          0x72be5d74f27b896fL, 0x80deb1fe3b1696b1L, 0x9bdc06a725c71235L, 0xc19bf174cf692694L,
-          0xe49b69c19ef14ad2L, 0xefbe4786384f25e3L, 0x0fc19dc68b8cd5b5L, 0x240ca1cc77ac9c65L,
-          0x2de92c6f592b0275L, 0x4a7484aa6ea6e483L, 0x5cb0a9dcbd41fbd4L, 0x76f988da831153b5L,
-          0x983e5152ee66dfabL, 0xa831c66d2db43210L, 0xb00327c898fb213fL, 0xbf597fc7beef0ee4L,
-          0xc6e00bf33da88fc2L, 0xd5a79147930aa725L, 0x06ca6351e003826fL, 0x142929670a0e6e70L,
-          0x27b70a8546d22ffcL, 0x2e1b21385c26c926L, 0x4d2c6dfc5ac42aedL, 0x53380d139d95b3dfL,
-          0x650a73548baf63deL, 0x766a0abb3c77b2a8L, 0x81c2c92e47edaee6L, 0x92722c851482353bL,
-          0xa2bfe8a14cf10364L, 0xa81a664bbc423001L, 0xc24b8b70d0f89791L, 0xc76c51a30654be30L,
-          0xd192e819d6ef5218L, 0xd69906245565a910L, 0xf40e35855771202aL, 0x106aa07032bbd1b8L,
-          0x19a4c116b8d2d0c8L, 0x1e376c085141ab53L, 0x2748774cdf8eeb99L, 0x34b0bcb5e19b48a8L,
-          0x391c0cb3c5c95a63L, 0x4ed8aa4ae3418acbL, 0x5b9cca4f7763e373L, 0x682e6ff3d6b2b8a3L,
-          0x748f82ee5defb2fcL, 0x78a5636f43172f60L, 0x84c87814a1f0ab72L, 0x8cc702081a6439ecL,
-          0x90befffa23631e28L, 0xa4506cebde82bde9L, 0xbef9a3f7b2c67915L, 0xc67178f2e372532bL,
-          0xca273eceea26619cL, 0xd186b8c721c0c207L, 0xeada7dd6cde0eb1eL, 0xf57d4f7fee6ed178L,
-          0x06f067aa72176fbaL, 0x0a637dc5a2c898a6L, 0x113f9804bef90daeL, 0x1b710b35131c471bL,
-          0x28db77f523047d84L, 0x32caab7b40c72493L, 0x3c9ebe0a15c9bebcL, 0x431d67c49c100d4cL,
-          0x4cc5d4becb3e42b6L, 0x597f299cfc657e2aL, 0x5fcb6fab3ad6faecL, 0x6c44198c4a475817L)
-    _h = (0x6a09e667f3bcc908L, 0xbb67ae8584caa73bL, 0x3c6ef372fe94f82bL, 0xa54ff53a5f1d36f1L,
-          0x510e527fade682d1L, 0x9b05688c2b3e6c1fL, 0x1f83d9abfb41bd6bL, 0x5be0cd19137e2179L)
+
+class sha512:
+    # fmt: off
+    _k = (0x428a2f98d728ae22, 0x7137449123ef65cd, 0xb5c0fbcfec4d3b2f, 0xe9b5dba58189dbbc,
+          0x3956c25bf348b538, 0x59f111f1b605d019, 0x923f82a4af194f9b, 0xab1c5ed5da6d8118,
+          0xd807aa98a3030242, 0x12835b0145706fbe, 0x243185be4ee4b28c, 0x550c7dc3d5ffb4e2,
+          0x72be5d74f27b896f, 0x80deb1fe3b1696b1, 0x9bdc06a725c71235, 0xc19bf174cf692694,
+          0xe49b69c19ef14ad2, 0xefbe4786384f25e3, 0x0fc19dc68b8cd5b5, 0x240ca1cc77ac9c65,
+          0x2de92c6f592b0275, 0x4a7484aa6ea6e483, 0x5cb0a9dcbd41fbd4, 0x76f988da831153b5,
+          0x983e5152ee66dfab, 0xa831c66d2db43210, 0xb00327c898fb213f, 0xbf597fc7beef0ee4,
+          0xc6e00bf33da88fc2, 0xd5a79147930aa725, 0x06ca6351e003826f, 0x142929670a0e6e70,
+          0x27b70a8546d22ffc, 0x2e1b21385c26c926, 0x4d2c6dfc5ac42aed, 0x53380d139d95b3df,
+          0x650a73548baf63de, 0x766a0abb3c77b2a8, 0x81c2c92e47edaee6, 0x92722c851482353b,
+          0xa2bfe8a14cf10364, 0xa81a664bbc423001, 0xc24b8b70d0f89791, 0xc76c51a30654be30,
+          0xd192e819d6ef5218, 0xd69906245565a910, 0xf40e35855771202a, 0x106aa07032bbd1b8,
+          0x19a4c116b8d2d0c8, 0x1e376c085141ab53, 0x2748774cdf8eeb99, 0x34b0bcb5e19b48a8,
+          0x391c0cb3c5c95a63, 0x4ed8aa4ae3418acb, 0x5b9cca4f7763e373, 0x682e6ff3d6b2b8a3,
+          0x748f82ee5defb2fc, 0x78a5636f43172f60, 0x84c87814a1f0ab72, 0x8cc702081a6439ec,
+          0x90befffa23631e28, 0xa4506cebde82bde9, 0xbef9a3f7b2c67915, 0xc67178f2e372532b,
+          0xca273eceea26619c, 0xd186b8c721c0c207, 0xeada7dd6cde0eb1e, 0xf57d4f7fee6ed178,
+          0x06f067aa72176fba, 0x0a637dc5a2c898a6, 0x113f9804bef90dae, 0x1b710b35131c471b,
+          0x28db77f523047d84, 0x32caab7b40c72493, 0x3c9ebe0a15c9bebc, 0x431d67c49c100d4c,
+          0x4cc5d4becb3e42b6, 0x597f299cfc657e2a, 0x5fcb6fab3ad6faec, 0x6c44198c4a475817)
+    _h = (0x6a09e667f3bcc908, 0xbb67ae8584caa73b, 0x3c6ef372fe94f82b, 0xa54ff53a5f1d36f1,
+          0x510e527fade682d1, 0x9b05688c2b3e6c1f, 0x1f83d9abfb41bd6b, 0x5be0cd19137e2179)
+    # fmt: on
     _output_size = 8
 
     blocksize = 1
     block_size = 128
     digest_size = 64
 
-    def __init__(self, m=None):
-        self._buffer = ''
+    def __init__(self, m: bytes | None = None) -> None:
+        self._buffer = b''
         self._counter = 0
 
         if m is not None:
-            if type(m) is not str:
-                raise TypeError, '%s() argument 1 must be string, not %s' % (self.__class__.__name__, type(m).__name__)
             self.update(m)
 
-    def _rotr(self, x, y):
-        return ((x >> y) | (x << (64-y))) & 0xFFFFFFFFFFFFFFFF
+    def _rotr(self, x: int, y: int) -> int:
+        return ((x >> y) | (x << (64 - y))) & 0xFFFFFFFFFFFFFFFF
 
-    def _sha512_process(self, chunk):
-        w = [0]*80
+    def _sha512_process(self, chunk: bytes) -> None:
+        w = [0] * 80
         w[0:16] = struct.unpack('!16Q', chunk)
 
         for i in range(16, 80):
-            s0 = self._rotr(w[i-15], 1) ^ self._rotr(w[i-15], 8) ^ (w[i-15] >> 7)
-            s1 = self._rotr(w[i-2], 19) ^ self._rotr(w[i-2], 61) ^ (w[i-2] >> 6)
-            w[i] = (w[i-16] + s0 + w[i-7] + s1) & 0xFFFFFFFFFFFFFFFF
+            s0 = self._rotr(w[i - 15], 1) ^ self._rotr(w[i - 15], 8) ^ (w[i - 15] >> 7)
+            s1 = self._rotr(w[i - 2], 19) ^ self._rotr(w[i - 2], 61) ^ (w[i - 2] >> 6)
+            w[i] = (w[i - 16] + s0 + w[i - 7] + s1) & 0xFFFFFFFFFFFFFFFF
 
-        a,b,c,d,e,f,g,h = self._h
+        a, b, c, d, e, f, g, h = self._h
 
         for i in range(80):
             s0 = self._rotr(a, 28) ^ self._rotr(a, 34) ^ self._rotr(a, 39)
@@ -76,13 +80,13 @@ class sha512(object):
             b = a
             a = (t1 + t2) & 0xFFFFFFFFFFFFFFFF
 
-        self._h = [(x+y) & 0xFFFFFFFFFFFFFFFF for x,y in zip(self._h, [a,b,c,d,e,f,g,h])]
+        self._h = [(x + y) & 0xFFFFFFFFFFFFFFFF for x, y in zip(self._h, [a, b, c, d, e, f, g, h], strict=True)]
 
-    def update(self, m):
+    def update(self, m: bytes) -> None:
         if not m:
             return
-        if type(m) is not str:
-            raise TypeError, '%s() argument 1 must be string, not %s' % (sys._getframe().f_code.co_name, type(m).__name__)
+        if not isinstance(m, bytes):
+            raise TypeError('%s() argument 1 must be bytes, not %s' % (sys._getframe().f_code.co_name, type(m).__name__))
 
         self._buffer += m
         self._counter += len(m)
@@ -91,21 +95,21 @@ class sha512(object):
             self._sha512_process(self._buffer[:128])
             self._buffer = self._buffer[128:]
 
-    def digest(self):
+    def digest(self) -> bytes:
         mdi = self._counter & 0x7F
-        length = struct.pack('!Q', self._counter<<3)
+        length = struct.pack('!Q', self._counter << 3)
 
         if mdi < 112:
-            padlen = 111-mdi
+            padlen = 111 - mdi
         else:
-            padlen = 239-mdi
+            padlen = 239 - mdi
 
         r = self.copy()
-        r.update('\x80'+('\x00'*(padlen+8))+length)
-        return ''.join([struct.pack('!Q', i) for i in r._h[:self._output_size]])
+        r.update(b'\x80' + (b'\x00' * (padlen + 8)) + length)
+        return b''.join([struct.pack('!Q', i) for i in r._h[: self._output_size]])
 
-    def hexdigest(self):
-        return self.digest().encode('hex')
+    def hexdigest(self) -> str:
+        return self.digest().hex()
 
-    def copy(self):
+    def copy(self) -> 'sha512':
         return copy.deepcopy(self)

--- a/test.py
+++ b/test.py
@@ -8,19 +8,19 @@ class TestSHA224(unittest.TestCase):
         self.f = sha224
 
     def test_empty(self):
-        self.assertEqual(self.f('').hexdigest(),
+        self.assertEqual(self.f(b'').hexdigest(),
                          'd14a028c2a3a2bc9476102bb288234c415a2b01f828ea62ac5b3e42f')
 
     def test_less_than_block_length(self):
-        self.assertEqual(self.f('abc').hexdigest(),
+        self.assertEqual(self.f(b'abc').hexdigest(),
                          '23097d223405d8228642a477bda255b32aadbce4bda0b3f7e36c9da7')
 
     def test_block_length(self):
-        self.assertEqual(self.f('a'*64).hexdigest(),
+        self.assertEqual(self.f(b'a'*64).hexdigest(),
                          'a88cd5cde6d6fe9136a4e58b49167461ea95d388ca2bdb7afdc3cbf4')
 
     def test_several_blocks(self):
-        self.assertEqual(self.f('a'*1000000).hexdigest(),
+        self.assertEqual(self.f(b'a'*1000000).hexdigest(),
                          '20794655980c91d8bbb4c1ea97618a4bf03f42581948b2ee4ee7ad67')
 
 class TestSHA256(unittest.TestCase):
@@ -28,19 +28,19 @@ class TestSHA256(unittest.TestCase):
         self.f = sha256
 
     def test_empty(self):
-        self.assertEqual(self.f('').hexdigest(),
+        self.assertEqual(self.f(b'').hexdigest(),
                          'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855')
 
     def test_less_than_block_length(self):
-        self.assertEqual(self.f('abc').hexdigest(),
+        self.assertEqual(self.f(b'abc').hexdigest(),
                          'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad')
 
     def test_block_length(self):
-        self.assertEqual(self.f('a'*64).hexdigest(),
+        self.assertEqual(self.f(b'a'*64).hexdigest(),
                          'ffe054fe7ae0cb6dc65c3af9b61d5209f439851db43d0ba5997337df154668eb')
 
     def test_several_blocks(self):
-        self.assertEqual(self.f('a'*1000000).hexdigest(),
+        self.assertEqual(self.f(b'a'*1000000).hexdigest(),
                          'cdc76e5c9914fb9281a1c7e284d73e67f1809a48a497200e046d39ccc7112cd0')
 
 class TestSHA384(unittest.TestCase):
@@ -48,22 +48,22 @@ class TestSHA384(unittest.TestCase):
         self.f = sha384
 
     def test_empty(self):
-        self.assertEqual(self.f('').hexdigest(),
+        self.assertEqual(self.f(b'').hexdigest(),
                          '38b060a751ac96384cd9327eb1b1e36a21fdb71114be0743'+
                          '4c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b')
 
     def test_less_than_block_length(self):
-        self.assertEqual(self.f('abc').hexdigest(),
+        self.assertEqual(self.f(b'abc').hexdigest(),
                          'cb00753f45a35e8bb5a03d699ac65007272c32ab0eded163'+
                          '1a8b605a43ff5bed8086072ba1e7cc2358baeca134c825a7')
 
     def test_block_length(self):
-        self.assertEqual(self.f('a'*128).hexdigest(),
+        self.assertEqual(self.f(b'a'*128).hexdigest(),
                          'edb12730a366098b3b2beac75a3bef1b0969b15c48e2163c'+
                          '23d96994f8d1bef760c7e27f3c464d3829f56c0d53808b0b')
 
     def test_several_blocks(self):
-        self.assertEqual(self.f('a'*1000000).hexdigest(),
+        self.assertEqual(self.f(b'a'*1000000).hexdigest(),
                          '9d0e1809716474cb086e834e310a4a1ced149e9c00f24852'+
                          '7972cec5704c2a5b07b8b3dc38ecc4ebae97ddd87f3d8985')
 
@@ -72,22 +72,22 @@ class TestSHA512(unittest.TestCase):
         self.f = sha512
 
     def test_empty(self):
-        self.assertEqual(self.f('').hexdigest(),
+        self.assertEqual(self.f(b'').hexdigest(),
                          'cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce'+
                          '47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e')
 
     def test_less_than_block_length(self):
-        self.assertEqual(self.f('abc').hexdigest(),
+        self.assertEqual(self.f(b'abc').hexdigest(),
                          'ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a'+
                          '2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f')
 
     def test_block_length(self):
-        self.assertEqual(self.f('a'*128).hexdigest(),
+        self.assertEqual(self.f(b'a'*128).hexdigest(),
                          'b73d1929aa615934e61a871596b3f3b33359f42b8175602e89f7e06e5f658a24'+
                          '3667807ed300314b95cacdd579f3e33abdfbe351909519a846d465c59582f321')
 
     def test_several_blocks(self):
-        self.assertEqual(self.f('a'*1000000).hexdigest(),
+        self.assertEqual(self.f(b'a'*1000000).hexdigest(),
                          'e718483d0ce769644e2e42c7bc15b4638e1f98b13b2044285632a803afa973eb'+
                          'de0ff244877ea60a4cb0432ce577c31beb009c5c2c49aa2e4eadb217ad8cc09b')
 


### PR DESCRIPTION
This sha implementation is very good for educational purposes, as it is very readable. Yet, with python2 being as depricated and hard to find as it is, an update seems to be in order.

- Changed 'str' to 'bytes'
- Applied autoformatter (spacing around operators)
- Added type-hints
- Removed 'L' suffix on integers
- Removed 'object' base class

This change breaks python2 compatibility. If there is any need to preserve python2-compatibility, let me know.